### PR TITLE
small fix to resize line shader on window resize

### DIFF
--- a/WallyMapSpinzor2.MonoGame/src/BaseGame.cs
+++ b/WallyMapSpinzor2.MonoGame/src/BaseGame.cs
@@ -18,6 +18,12 @@ public class BaseGame : Game
         IsMouseVisible = true;
         Window.AllowUserResizing = true;
         Window.Title = "WallyMapSpinzor2.MonoGame";
+        Window.ClientSizeChanged += OnWindowResize;
+    }
+
+    private void OnWindowResize(object? sender, EventArgs e)
+    {
+        Canvas?.ResizeLineShader();
     }
 
     protected override void Draw(GameTime gameTime)

--- a/WallyMapSpinzor2.MonoGame/src/MonoGameCanvas.cs
+++ b/WallyMapSpinzor2.MonoGame/src/MonoGameCanvas.cs
@@ -167,6 +167,16 @@ public class MonoGameCanvas : ICanvas<Texture2DWrapper>
         TextureCache.Clear();
     }
 
+    public void ResizeLineShader()
+    {
+        if(_lineShader is null) return;
+
+        _lineShader.Projection = Matrix.CreateOrthographicOffCenter
+                (0, Batch.GraphicsDevice.Viewport.Width,
+                Batch.GraphicsDevice.Viewport.Height, 0,
+                0, 1);
+    }
+
     public Texture2DWrapper LoadTextureFromSWF(string filePath, string name)
     {
         return new(null);


### PR DESCRIPTION
Resize line shader when necessary to render lines correctly when the window is resized by the user